### PR TITLE
DRY some of the Slack resolution logic and consolidate the file upload message.

### DIFF
--- a/gateway/message_parser.go
+++ b/gateway/message_parser.go
@@ -10,6 +10,12 @@ import (
 // ParseMessageText takes raw Slack message payload and resolves the user
 // and channel references
 func (sc *SlackClient) ParseMessageText(text string) string {
+	return sc.ParseMessageTextWithOptions(text, false)
+}
+
+// ParseMessageTextWithOptions takes raw Slack message payload, resolves the
+// user and channel references, and optionally preserves the Slack canonical URL.
+func (sc *SlackClient) ParseMessageTextWithOptions(text string, includeCanonicalURL bool) string {
 	parsedMessageBuilder := strings.Builder{}
 
 	// Find the first '<' if any, split into "before" and "after"
@@ -47,9 +53,13 @@ func (sc *SlackClient) ParseMessageText(text string) string {
 			parsedMessageBuilder.WriteString(channelRefParts[1])
 
 		default:
-			// A URL, we only care about the "display" portion that was actually sent.
+			// A URL, we usually only care about the "display" portion that was actually sent.
 			displayIdx := strings.Index(ref, "|")
 			parsedMessageBuilder.WriteString(ref[displayIdx+1:])
+			if includeCanonicalURL && displayIdx > 0 {
+				parsedMessageBuilder.WriteByte(' ')
+				parsedMessageBuilder.WriteString(ref[0:displayIdx])
+			}
 		}
 
 		// Do it again I guess.

--- a/gateway/message_parser_test.go
+++ b/gateway/message_parser_test.go
@@ -77,6 +77,44 @@ func TestSlackClient_ParseMessageText(t *testing.T) {
 	}
 }
 
+func TestSlackClient_ParseMessageTextWithOptions(t *testing.T) {
+	type fields struct {
+		channelInfo map[string]*SlackChannel
+		userInfo    map[string]*SlackUser
+	}
+	type params struct {
+		text                string
+		includeCanonicalURL bool
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		params params
+		want   string
+	}{
+		{
+			name:   "URL detected by slack",
+			fields: fields{},
+			params: params{
+				text:                "Fork this cool github repo <http://github.com/nolanlum/tanya|github.com/nolanlum/tanya> xD",
+				includeCanonicalURL: true,
+			},
+			want: "Fork this cool github repo github.com/nolanlum/tanya http://github.com/nolanlum/tanya xD",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sc := NewSlackClient()
+			sc.channelInfo = tt.fields.channelInfo
+			sc.userInfo = tt.fields.userInfo
+
+			if got := sc.ParseMessageTextWithOptions(tt.params.text, tt.params.includeCanonicalURL); got != tt.want {
+				t.Errorf("SlackClient.ParseMessageTextWithOptions() = \"%v\", want \"%v\"", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSlackClient_UnparseMessageText(t *testing.T) {
 	type fields struct {
 		channelInfo map[string]*SlackChannel

--- a/gateway/slack.go
+++ b/gateway/slack.go
@@ -412,6 +412,7 @@ func (sc *SlackClient) Poop(chans *ClientChans) {
 					var err error
 					if sender, err = sc.ResolveUser(messageData.User); err != nil {
 						log.Printf("could not resolve user for message [%v]: %+v", err, messageData)
+						continue
 					}
 				}
 
@@ -420,12 +421,14 @@ func (sc *SlackClient) Poop(chans *ClientChans) {
 					if isDmChannel(messageData.Channel) {
 						if targetUser, err := sc.ResolveDMToUser(messageData.Channel); err != nil {
 							log.Printf("could not resolve DM target for message [%v]: %+v", err, messageData)
+							continue
 						} else {
 							target = targetUser.Nick
 						}
 					} else {
 						if channel, err := sc.ResolveChannel(messageData.Channel); err != nil {
 							log.Printf("could not resolve channel for message [%v]: %+v", err, messageData)
+							continue
 						} else {
 							target = channel.Name
 						}
@@ -474,6 +477,10 @@ func (sc *SlackClient) Poop(chans *ClientChans) {
 						continue
 					}
 
+					if target == "" {
+						continue
+					}
+
 					user, err := sc.ResolveUser(subMessage.User)
 					if err != nil {
 						log.Printf("could not resolve user for archive link [%v]: %+v", err, messageData.SubMessage)
@@ -495,6 +502,10 @@ func (sc *SlackClient) Poop(chans *ClientChans) {
 					)
 
 				case "channel_topic":
+					if sender == nil || target == "" {
+						continue
+					}
+
 					chans.IncomingChan <- &SlackEvent{
 						EventType: TopicChangeEvent,
 						Data: &TopicChangeEventData{


### PR DESCRIPTION
File upload events actually come with text that is somewhat useful; to keep parity with the existing slack gateway we'll just regurgitate that text ala normal slack messages, except preserving the weird markdown-ish URL thing Slack does.