### PR TITLE
Send JOIN/PART messages when necessary.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -17,7 +17,7 @@
   branch = "tanya"
   name = "github.com/nlopes/slack"
   packages = ["."]
-  revision = "89cc0495a2457594f6d9d6af6663d94e2133d63e"
+  revision = "44f457d686918d1aa3bf51d09e4de07cd93d6467"
   source = "github.com/nolanlum/slack"
 
 [[projects]]

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -17,7 +17,7 @@
   branch = "tanya"
   name = "github.com/nlopes/slack"
   packages = ["."]
-  revision = "44f457d686918d1aa3bf51d09e4de07cd93d6467"
+  revision = "e78ee0fe2e1e60612f360e7b1ad18fab4e01f330"
   source = "github.com/nolanlum/slack"
 
 [[projects]]

--- a/gateway/channel_users.go
+++ b/gateway/channel_users.go
@@ -1,0 +1,126 @@
+package gateway
+
+import "github.com/nlopes/slack"
+
+// getChannelUsersFromAPI queries the Slack API for a list of users in the given channel, returning
+// SlackUser objects for each one
+func (sc *SlackClient) getChannelUsersFromAPI(channelID string) (users []*SlackUser, err error) {
+	hasMore := true
+	guicp := &slack.GetUsersInConversationParameters{
+		ChannelID: channelID,
+		Limit:     1000,
+	}
+	for hasMore {
+		var userIDs []string
+		userIDs, guicp.Cursor, err = sc.client.GetUsersInConversation(guicp)
+		if err != nil {
+			return
+		}
+
+		for _, userID := range userIDs {
+			var user *SlackUser
+			user, err = sc.ResolveUser(userID)
+			if err != nil {
+				return
+			}
+			users = append(users, user)
+		}
+
+		hasMore = guicp.Cursor != ""
+	}
+
+	return
+}
+
+// GetChannelUsers returns a locally cached list of users in the given channel
+func (sc *SlackClient) GetChannelUsers(channelID string) ([]SlackUser, error) {
+	sc.RLock()
+	if channelMembers, found := sc.channelMembers[channelID]; found {
+		users := make([]SlackUser, 0)
+		for _, user := range channelMembers {
+			users = append(users, *user)
+		}
+
+		sc.RUnlock()
+		return users, nil
+	}
+	sc.RUnlock()
+
+	channelMembers, err := sc.getChannelUsersFromAPI(channelID)
+	if err != nil {
+		return nil, err
+	}
+
+	channelMemberMap := make(map[string]*SlackUser)
+	for _, user := range channelMembers {
+		channelMemberMap[user.SlackID] = user
+	}
+
+	sc.Lock()
+	sc.channelMembers[channelID] = channelMemberMap
+	sc.Unlock()
+
+	users := make([]SlackUser, 0)
+	for _, user := range channelMembers {
+		users = append(users, *user)
+	}
+	return users, nil
+}
+
+func (sc *SlackClient) handleMemberJoinedChannel(channelID, userID string) (*SlackEvent, error) {
+	user, err := sc.ResolveUser(userID)
+	if err != nil {
+		return nil, err
+	}
+
+	target, err := sc.ResolveChannel(channelID)
+	if err != nil {
+		return nil, err
+	}
+
+	sc.RLock()
+	_, found := sc.channelMembers[channelID]
+	sc.RUnlock()
+	if found {
+		sc.Lock()
+		sc.channelMembers[channelID][userID] = user
+		sc.Unlock()
+	}
+
+	return &SlackEvent{
+		EventType: JoinEvent,
+		Data: &JoinPartEventData{
+			User:   *user,
+			Target: target.Name,
+		},
+	}, nil
+}
+
+func (sc *SlackClient) handleMemberLeftChannel(channelID, userID string) (*SlackEvent, error) {
+	user, err := sc.ResolveUser(userID)
+	if err != nil {
+		return nil, err
+	}
+
+	target, err := sc.ResolveChannel(channelID)
+	if err != nil {
+		return nil, err
+	}
+
+	sc.RLock()
+	_, found := sc.channelMembers[channelID]
+	sc.RUnlock()
+	if found {
+		sc.Lock()
+		delete(sc.channelMembers[channelID], userID)
+		sc.Unlock()
+	}
+
+	return &SlackEvent{
+		EventType: PartEvent,
+		Data: &JoinPartEventData{
+			User:   *user,
+			Target: target.Name,
+		},
+	}, nil
+}

--- a/gateway/events.go
+++ b/gateway/events.go
@@ -46,3 +46,9 @@ type TopicChangeEventData struct {
 	Target   string
 	NewTopic string
 }
+
+// JoinPartEventData represents a user joining or leaving a channel
+type JoinPartEventData struct {
+	User   SlackUser
+	Target string
+}

--- a/gateway/slack.go
+++ b/gateway/slack.go
@@ -575,7 +575,7 @@ func (sc *SlackClient) Poop(chans *ClientChans) {
 
 			case "member_left_channel":
 				memberLeftChannelEvent := event.Data.(*slack.MemberLeftChannelEvent)
-				partEvent, err := sc.handleMemberJoinedChannel(
+				partEvent, err := sc.handleMemberLeftChannel(
 					memberLeftChannelEvent.Channel, memberLeftChannelEvent.User)
 
 				if err != nil {

--- a/gateway/slack.go
+++ b/gateway/slack.go
@@ -63,6 +63,7 @@ type SlackClient struct {
 	userInfo           map[string]*SlackUser
 	dmInfo             map[string]*SlackUser
 	channelMemberships map[string]*SlackChannel
+	channelMembers     map[string]map[string]*SlackUser
 
 	nickToUserMap      map[string]string
 	channelNameToIDMap map[string]string
@@ -78,7 +79,9 @@ func NewSlackClient() *SlackClient {
 	return &SlackClient{
 		channelInfo:        make(map[string]*SlackChannel),
 		userInfo:           make(map[string]*SlackUser),
+		dmInfo:             make(map[string]*SlackUser),
 		channelMemberships: make(map[string]*SlackChannel),
+		channelMembers:     make(map[string]map[string]*SlackUser),
 
 		slackURLEncoder: strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;"),
 		slackURLDecoder: strings.NewReplacer("&gt;", ">", "&lt;", "<", "&amp;", "&"),
@@ -279,36 +282,6 @@ func (sc *SlackClient) ResolveDMToUser(dmChannelID string) (*SlackUser, error) {
 	return nil, fmt.Errorf("could not find user for DM: %s", dmChannelID)
 }
 
-// GetChannelUsers queries the Slack API for a list of users in the given channel, returning
-// SlackUser objects for each one
-func (sc *SlackClient) GetChannelUsers(channelID string) (users []SlackUser, err error) {
-	hasMore := true
-	guicp := &slack.GetUsersInConversationParameters{
-		ChannelID: channelID,
-		Limit:     1000,
-	}
-	for hasMore {
-		var userIDs []string
-		userIDs, guicp.Cursor, err = sc.client.GetUsersInConversation(guicp)
-		if err != nil {
-			return
-		}
-
-		for _, userID := range userIDs {
-			var user *SlackUser
-			user, err = sc.ResolveUser(userID)
-			if err != nil {
-				return
-			}
-			users = append(users, *user)
-		}
-
-		hasMore = guicp.Cursor != ""
-	}
-
-	return
-}
-
 // GetChannelMemberships returns the channels this SlackClient is a member of
 func (sc *SlackClient) GetChannelMemberships() (channels []SlackChannel) {
 	sc.RLock()
@@ -390,6 +363,16 @@ func (sc *SlackClient) Poop(chans *ClientChans) {
 				connEventError := event.Data.(*slack.ConnectionErrorEvent)
 				log.Printf("error connecting to slack: %v\n", connEventError.Error())
 
+			case "connecting":
+				connectingData := event.Data.(*slack.ConnectingEvent)
+
+				verb := "connecting"
+				if connectingData.ConnectionCount > 1 {
+					verb = "reconnecting"
+				}
+				chans.IncomingChan <- sc.newInternalMessageEvent(fmt.Sprintf(
+					"%s to slack (attempt %d)", verb, connectingData.Attempt))
+
 			case "connected":
 				connectedData := event.Data.(*slack.ConnectedEvent)
 				sc.bootstrapMappings()
@@ -403,6 +386,13 @@ func (sc *SlackClient) Poop(chans *ClientChans) {
 						UserInfo: sc.self,
 					},
 				}
+
+			case "hello":
+				chans.IncomingChan <- sc.newInternalMessageEvent("connected to slack!")
+
+			case "disconnected":
+				log.Println("tanya disconnected from slack")
+				chans.IncomingChan <- sc.newInternalMessageEvent("disconnected from slack!")
 
 			case "message":
 				messageData := event.Data.(*slack.MessageEvent)
@@ -467,7 +457,7 @@ func (sc *SlackClient) Poop(chans *ClientChans) {
 
 				case "message_changed":
 					if messageData.SubMessage == nil || messageData.SubMessage.SubType != "" {
-						chans.IncomingChan <- sc.newInternalMessageEvent(fmt.Sprintf("%+v", messageData))
+						log.Printf("message_changed with unexpected or missing submessage: %+v", messageData)
 						continue
 					}
 					subMessage := messageData.SubMessage
@@ -515,8 +505,12 @@ func (sc *SlackClient) Poop(chans *ClientChans) {
 						},
 					}
 
+				case "channel_leave", "channel_join":
+					// These are already handled elsewhere, drop the message event.
+					continue
+
 				default:
-					chans.IncomingChan <- sc.newInternalMessageEvent(fmt.Sprintf("%v: %+v", event.Type, event.Data))
+					log.Printf("unhandled submessage type [%v]: %+v", messageData.SubType, event.Data)
 				}
 
 			case "user_change":
@@ -547,7 +541,6 @@ func (sc *SlackClient) Poop(chans *ClientChans) {
 				fileSharedEvent := event.Data.(*slack.FileSharedEvent)
 				file := fileSharedEvent.File
 				if len(file.Channels) == 0 {
-					log.Printf("file not shared to any channels: %+v\n", fileSharedEvent)
 					continue
 				}
 
@@ -568,9 +561,33 @@ func (sc *SlackClient) Poop(chans *ClientChans) {
 				)
 				chans.IncomingChan <- newSlackMessageEvent(user, target.Name, sc.slackURLDecoder.Replace(shareMessage))
 
-			case "channel_marked", "group_marked", "latency_report",
-				"user_typing", "pref_change", "dnd_updated_user",
-				"file_public":
+			case "member_joined_channel":
+				memberJoinedChannelEvent := event.Data.(*slack.MemberJoinedChannelEvent)
+				joinEvent, err := sc.handleMemberJoinedChannel(
+					memberJoinedChannelEvent.Channel, memberJoinedChannelEvent.User)
+
+				if err != nil {
+					joinEvent = sc.newInternalMessageEvent(fmt.Sprintf(
+						"error handling member_joined_channel event [%v]: %+v", err, memberJoinedChannelEvent))
+				}
+
+				chans.IncomingChan <- joinEvent
+
+			case "member_left_channel":
+				memberLeftChannelEvent := event.Data.(*slack.MemberLeftChannelEvent)
+				partEvent, err := sc.handleMemberJoinedChannel(
+					memberLeftChannelEvent.Channel, memberLeftChannelEvent.User)
+
+				if err != nil {
+					partEvent = sc.newInternalMessageEvent(fmt.Sprintf(
+						"error handling member_left_channel event [%v]: %+v", err, memberLeftChannelEvent))
+				}
+
+				chans.IncomingChan <- partEvent
+
+			case "channel_marked", "group_marked", "thread_marked", "im_marked",
+				"latency_report", "user_typing", "pref_change", "dnd_updated_user",
+				"file_public", "reaction_added":
 				// haha nobody cares about this
 
 			case "ack":
@@ -581,7 +598,7 @@ func (sc *SlackClient) Poop(chans *ClientChans) {
 				fallthrough
 
 			default:
-				chans.IncomingChan <- sc.newInternalMessageEvent(fmt.Sprintf("%v: %+v", event.Type, event.Data))
+				log.Printf("unhandled event [%v]: %+v", event.Type, event.Data)
 			}
 		}
 	}

--- a/irc/util.go
+++ b/irc/util.go
@@ -101,6 +101,22 @@ func (j *Join) ToMessage() *Message {
 	}
 }
 
+// Part is a PART message
+type Part struct {
+	User    User
+	Channel string
+	Message string
+}
+
+// ToMessage turns a Join into a Message
+func (j *Part) ToMessage() *Message {
+	return &Message{
+		j.User.String(),
+		PartCmd,
+		[]string{j.Channel, j.Message},
+	}
+}
+
 // Topic is a TOPIC message
 type Topic struct {
 	From    User

--- a/main.go
+++ b/main.go
@@ -49,6 +49,21 @@ func slackToTopic(t *gateway.TopicChangeEventData) *irc.Topic {
 	}
 }
 
+func slackToJoin(j *gateway.JoinPartEventData) *irc.Join {
+	return &irc.Join{
+		User:    slackUserToIRCUser(&j.User),
+		Channel: j.Target,
+	}
+}
+
+func slackToPart(j *gateway.JoinPartEventData) *irc.Part {
+	return &irc.Part{
+		User:    slackUserToIRCUser(&j.User),
+		Channel: j.Target,
+		Message: "Leaving",
+	}
+}
+
 // this name specially chosen to trigger ATRAN
 type corpusCallosum struct {
 	sc *gateway.SlackClient
@@ -171,6 +186,12 @@ Loop:
 			case gateway.TopicChangeEvent:
 				t := slackToTopic(msg.Data.(*gateway.TopicChangeEventData))
 				sendChan <- t.ToMessage()
+			case gateway.JoinEvent:
+				j := slackToJoin(msg.Data.(*gateway.JoinPartEventData))
+				sendChan <- j.ToMessage()
+			case gateway.PartEvent:
+				p := slackToPart(msg.Data.(*gateway.JoinPartEventData))
+				sendChan <- p.ToMessage()
 			}
 		}
 	}

--- a/vendor/github.com/nlopes/slack/admin.go
+++ b/vendor/github.com/nlopes/slack/admin.go
@@ -62,6 +62,7 @@ func (api *Client) InviteGuestContext(ctx context.Context, teamName, channel, fi
 		"last_name":        {lastName},
 		"ultra_restricted": {"1"},
 		"token":            {api.token},
+		"resend":           {"true"},
 		"set_active":       {"true"},
 		"_attempts":        {"1"},
 	}
@@ -88,6 +89,7 @@ func (api *Client) InviteRestrictedContext(ctx context.Context, teamName, channe
 		"last_name":  {lastName},
 		"restricted": {"1"},
 		"token":      {api.token},
+		"resend":     {"true"},
 		"set_active": {"true"},
 		"_attempts":  {"1"},
 	}

--- a/vendor/github.com/nlopes/slack/misc.go
+++ b/vendor/github.com/nlopes/slack/misc.go
@@ -180,3 +180,9 @@ func okJsonHandler(rw http.ResponseWriter, r *http.Request) {
 	})
 	rw.Write(response)
 }
+
+type errorString string
+
+func (t errorString) Error() string {
+	return string(t)
+}

--- a/vendor/github.com/nlopes/slack/slack.go
+++ b/vendor/github.com/nlopes/slack/slack.go
@@ -40,6 +40,19 @@ type SlackResponse struct {
 	Error string `json:"error"`
 }
 
+// ResponseMetadata holds pagination metadata
+type ResponseMetadata struct {
+	Cursor string `json:"next_cursor"`
+}
+
+func (t *ResponseMetadata) initialize() *ResponseMetadata {
+	if t != nil {
+		return t
+	}
+
+	return &ResponseMetadata{}
+}
+
 type AuthTestResponse struct {
 	URL    string `json:"url"`
 	Team   string `json:"team"`

--- a/vendor/github.com/nlopes/slack/users.go
+++ b/vendor/github.com/nlopes/slack/users.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"log"
 	"net/url"
 	"strconv"
 )
@@ -12,31 +13,40 @@ const (
 	DEFAULT_USER_PHOTO_CROP_X = -1
 	DEFAULT_USER_PHOTO_CROP_Y = -1
 	DEFAULT_USER_PHOTO_CROP_W = -1
+	errPaginationComplete     = errorString("pagination complete")
 )
 
 // UserProfile contains all the information details of a given user
 type UserProfile struct {
-	FirstName             string `json:"first_name"`
-	LastName              string `json:"last_name"`
-	RealName              string `json:"real_name"`
-	RealNameNormalized    string `json:"real_name_normalized"`
-	DisplayName           string `json:"display_name"`
-	DisplayNameNormalized string `json:"display_name_normalized"`
-	Email                 string `json:"email"`
-	Skype                 string `json:"skype"`
-	Phone                 string `json:"phone"`
-	Image24               string `json:"image_24"`
-	Image32               string `json:"image_32"`
-	Image48               string `json:"image_48"`
-	Image72               string `json:"image_72"`
-	Image192              string `json:"image_192"`
-	ImageOriginal         string `json:"image_original"`
-	Title                 string `json:"title"`
-	BotID                 string `json:"bot_id,omitempty"`
-	ApiAppID              string `json:"api_app_id,omitempty"`
-	StatusText            string `json:"status_text,omitempty"`
-	StatusEmoji           string `json:"status_emoji,omitempty"`
-	Team                  string `json:"team"`
+	FirstName             string                            `json:"first_name"`
+	LastName              string                            `json:"last_name"`
+	RealName              string                            `json:"real_name"`
+	RealNameNormalized    string                            `json:"real_name_normalized"`
+	DisplayName           string                            `json:"display_name"`
+	DisplayNameNormalized string                            `json:"display_name_normalized"`
+	Email                 string                            `json:"email"`
+	Skype                 string                            `json:"skype"`
+	Phone                 string                            `json:"phone"`
+	Image24               string                            `json:"image_24"`
+	Image32               string                            `json:"image_32"`
+	Image48               string                            `json:"image_48"`
+	Image72               string                            `json:"image_72"`
+	Image192              string                            `json:"image_192"`
+	ImageOriginal         string                            `json:"image_original"`
+	Title                 string                            `json:"title"`
+	BotID                 string                            `json:"bot_id,omitempty"`
+	ApiAppID              string                            `json:"api_app_id,omitempty"`
+	StatusText            string                            `json:"status_text,omitempty"`
+	StatusEmoji           string                            `json:"status_emoji,omitempty"`
+	Team                  string                            `json:"team"`
+	Fields                map[string]UserProfileCustomField `json:"fields"`
+}
+
+// UserProfileCustomField represents a custom user profile field
+type UserProfileCustomField struct {
+	Value string `json:"value"`
+	Alt   string `json:"alt"`
+	Label string `json:"label"`
 }
 
 // User contains all the information of a user
@@ -113,6 +123,7 @@ type userResponseFull struct {
 	User         `json:"user,omitempty"` // GetUserInfo
 	UserPresence                         // GetUserPresence
 	SlackResponse
+	Metadata ResponseMetadata
 }
 
 type UserSetPhotoParams struct {
@@ -179,23 +190,110 @@ func (api *Client) GetUserInfoContext(ctx context.Context, user string) (*User, 
 	return &response.User, nil
 }
 
+// GetUsersOption options for the GetUsers method call.
+type GetUsersOption func(*UserPagination)
+
+// GetUsersOptionLimit limit the number of users returned
+func GetUsersOptionLimit(n int) GetUsersOption {
+	return func(p *UserPagination) {
+		p.limit = n
+	}
+}
+
+// GetUsersOptionPresence include user presence
+func GetUsersOptionPresence(n bool) GetUsersOption {
+	return func(p *UserPagination) {
+		p.presence = n
+	}
+}
+
+func newUserPagination(c *Client, options ...GetUsersOption) (up UserPagination) {
+	up = UserPagination{
+		c:     c,
+		limit: 200, // per slack api documentation.
+	}
+
+	for _, opt := range options {
+		opt(&up)
+	}
+
+	return up
+}
+
+// UserPagination allows for paginating over the users
+type UserPagination struct {
+	Users        []User
+	limit        int
+	presence     bool
+	previousResp *ResponseMetadata
+	c            *Client
+}
+
+// Done checks if the pagination has completed
+func (UserPagination) Done(err error) bool {
+	return err == errPaginationComplete
+}
+
+// Failure checks if pagination failed.
+func (t UserPagination) Failure(err error) error {
+	if t.Done(err) {
+		return nil
+	}
+
+	return err
+}
+
+func (t UserPagination) Next(ctx context.Context) (_ UserPagination, err error) {
+	var (
+		resp *userResponseFull
+	)
+
+	if t.c == nil || (t.previousResp != nil && t.previousResp.Cursor == "") {
+		return t, errPaginationComplete
+	}
+
+	t.previousResp = t.previousResp.initialize()
+
+	values := url.Values{
+		"limit":    {strconv.Itoa(t.limit)},
+		"presence": {strconv.FormatBool(t.presence)},
+		"token":    {t.c.token},
+		"cursor":   {t.previousResp.Cursor},
+	}
+
+	if resp, err = userRequest(ctx, t.c.httpclient, "users.list", values, t.c.debug); err != nil {
+		log.Println("error during user request", err)
+		return t, err
+	}
+
+	t.c.Debugf("GetUsersContext: got %d users; metadata %v", len(resp.Members), resp.Metadata)
+	t.Users = resp.Members
+	t.previousResp = &resp.Metadata
+
+	return t, nil
+}
+
+// GetUsersPaginated fetches users in a paginated fashion, see GetUsersContext for usage.
+func (api *Client) GetUsersPaginated(options ...GetUsersOption) UserPagination {
+	return newUserPagination(api, options...)
+}
+
 // GetUsers returns the list of users (with their detailed information)
 func (api *Client) GetUsers() ([]User, error) {
 	return api.GetUsersContext(context.Background())
 }
 
 // GetUsersContext returns the list of users (with their detailed information) with a custom context
-func (api *Client) GetUsersContext(ctx context.Context) ([]User, error) {
-	values := url.Values{
-		"token":    {api.token},
-		"presence": {"1"},
+func (api *Client) GetUsersContext(ctx context.Context) (results []User, err error) {
+	var (
+		p UserPagination
+	)
+
+	for p = api.GetUsersPaginated(); !p.Done(err); p, err = p.Next(ctx) {
+		results = append(results, p.Users...)
 	}
 
-	response, err := userRequest(ctx, api.httpclient, "users.list", values, api.debug)
-	if err != nil {
-		return nil, err
-	}
-	return response.Members, nil
+	return results, p.Failure(err)
 }
 
 // GetUserByEmail will retrieve the complete user information by email
@@ -392,4 +490,32 @@ func (api *Client) UnsetUserCustomStatus() error {
 // with a custom context. This is a convenience method that wraps (*Client).SetUserCustomStatus().
 func (api *Client) UnsetUserCustomStatusContext(ctx context.Context) error {
 	return api.SetUserCustomStatusContext(ctx, "", "")
+}
+
+// GetUserProfile retrieves a user's profile information.
+func (api *Client) GetUserProfile(userID string, includeLabels bool) (*UserProfile, error) {
+	return api.GetUserProfileContext(context.Background(), userID, includeLabels)
+}
+
+type getUserProfileResponse struct {
+	SlackResponse
+	Profile *UserProfile `json:"profile"`
+}
+
+// GetUserProfileContext retrieves a user's profile information with a context.
+func (api *Client) GetUserProfileContext(ctx context.Context, userID string, includeLabels bool) (*UserProfile, error) {
+	values := url.Values{"token": {api.token}, "user": {userID}}
+	if includeLabels {
+		values.Add("include_labels", "true")
+	}
+	resp := &getUserProfileResponse{}
+
+	err := post(ctx, api.httpclient, "users.profile.get", values, &resp, api.debug)
+	if err != nil {
+		return nil, err
+	}
+	if !resp.Ok {
+		return nil, errors.New(resp.Error)
+	}
+	return resp.Profile, nil
 }

--- a/vendor/github.com/nlopes/slack/users.go
+++ b/vendor/github.com/nlopes/slack/users.go
@@ -18,35 +18,27 @@ const (
 
 // UserProfile contains all the information details of a given user
 type UserProfile struct {
-	FirstName             string                            `json:"first_name"`
-	LastName              string                            `json:"last_name"`
-	RealName              string                            `json:"real_name"`
-	RealNameNormalized    string                            `json:"real_name_normalized"`
-	DisplayName           string                            `json:"display_name"`
-	DisplayNameNormalized string                            `json:"display_name_normalized"`
-	Email                 string                            `json:"email"`
-	Skype                 string                            `json:"skype"`
-	Phone                 string                            `json:"phone"`
-	Image24               string                            `json:"image_24"`
-	Image32               string                            `json:"image_32"`
-	Image48               string                            `json:"image_48"`
-	Image72               string                            `json:"image_72"`
-	Image192              string                            `json:"image_192"`
-	ImageOriginal         string                            `json:"image_original"`
-	Title                 string                            `json:"title"`
-	BotID                 string                            `json:"bot_id,omitempty"`
-	ApiAppID              string                            `json:"api_app_id,omitempty"`
-	StatusText            string                            `json:"status_text,omitempty"`
-	StatusEmoji           string                            `json:"status_emoji,omitempty"`
-	Team                  string                            `json:"team"`
-	Fields                map[string]UserProfileCustomField `json:"fields"`
-}
-
-// UserProfileCustomField represents a custom user profile field
-type UserProfileCustomField struct {
-	Value string `json:"value"`
-	Alt   string `json:"alt"`
-	Label string `json:"label"`
+	FirstName             string `json:"first_name"`
+	LastName              string `json:"last_name"`
+	RealName              string `json:"real_name"`
+	RealNameNormalized    string `json:"real_name_normalized"`
+	DisplayName           string `json:"display_name"`
+	DisplayNameNormalized string `json:"display_name_normalized"`
+	Email                 string `json:"email"`
+	Skype                 string `json:"skype"`
+	Phone                 string `json:"phone"`
+	Image24               string `json:"image_24"`
+	Image32               string `json:"image_32"`
+	Image48               string `json:"image_48"`
+	Image72               string `json:"image_72"`
+	Image192              string `json:"image_192"`
+	ImageOriginal         string `json:"image_original"`
+	Title                 string `json:"title"`
+	BotID                 string `json:"bot_id,omitempty"`
+	ApiAppID              string `json:"api_app_id,omitempty"`
+	StatusText            string `json:"status_text,omitempty"`
+	StatusEmoji           string `json:"status_emoji,omitempty"`
+	Team                  string `json:"team"`
 }
 
 // User contains all the information of a user
@@ -490,32 +482,4 @@ func (api *Client) UnsetUserCustomStatus() error {
 // with a custom context. This is a convenience method that wraps (*Client).SetUserCustomStatus().
 func (api *Client) UnsetUserCustomStatusContext(ctx context.Context) error {
 	return api.SetUserCustomStatusContext(ctx, "", "")
-}
-
-// GetUserProfile retrieves a user's profile information.
-func (api *Client) GetUserProfile(userID string, includeLabels bool) (*UserProfile, error) {
-	return api.GetUserProfileContext(context.Background(), userID, includeLabels)
-}
-
-type getUserProfileResponse struct {
-	SlackResponse
-	Profile *UserProfile `json:"profile"`
-}
-
-// GetUserProfileContext retrieves a user's profile information with a context.
-func (api *Client) GetUserProfileContext(ctx context.Context, userID string, includeLabels bool) (*UserProfile, error) {
-	values := url.Values{"token": {api.token}, "user": {userID}}
-	if includeLabels {
-		values.Add("include_labels", "true")
-	}
-	resp := &getUserProfileResponse{}
-
-	err := post(ctx, api.httpclient, "users.profile.get", values, &resp, api.debug)
-	if err != nil {
-		return nil, err
-	}
-	if !resp.Ok {
-		return nil, errors.New(resp.Error)
-	}
-	return resp.Profile, nil
 }

--- a/vendor/github.com/nlopes/slack/websocket_misc.go
+++ b/vendor/github.com/nlopes/slack/websocket_misc.go
@@ -41,6 +41,9 @@ type RTMEvent struct {
 // HelloEvent represents the hello event
 type HelloEvent struct{}
 
+// GoodbyeEvent represents the goodbye event
+type GoodbyeEvent struct{}
+
 // PresenceChangeEvent represents the presence change event
 type PresenceChangeEvent struct {
 	Type     string `json:"type"`


### PR DESCRIPTION
Also some quality of life improvements: channel user lists are cached, unhandled messages will no longer go to *tanya but are instead logged to stdout (they were too damn long)

Fixes #27