### PR TITLE
Separate a new SelfJoinEvent type out of Slack JoinEvent.

### DIFF
--- a/gateway/channel_users.go
+++ b/gateway/channel_users.go
@@ -120,8 +120,13 @@ func (sc *SlackClient) handleMemberJoinedChannel(channelID, userID string) (*Sla
 		sc.Unlock()
 	}
 
+	eventType := JoinEvent
+	if user == sc.self {
+		eventType = SelfJoinEvent
+	}
+
 	return &SlackEvent{
-		EventType: JoinEvent,
+		EventType: eventType,
 		Data: &JoinPartEventData{
 			User:   *user,
 			Target: target.Name,

--- a/gateway/events.go
+++ b/gateway/events.go
@@ -9,6 +9,7 @@ const (
 	MessageEvent
 	NickChangeEvent
 	TopicChangeEvent
+	SelfJoinEvent
 	JoinEvent
 	PartEvent
 )

--- a/irc/server.go
+++ b/irc/server.go
@@ -188,6 +188,17 @@ func (s *Server) HandleConnectBurst(selfUser User) {
 	s.initOnce.Do(func() { close(s.initChan) })
 }
 
+// HandleChannelJoined handles a Slack-initiated channel membership change event.
+// This special signalling is necessary due to the extra data (NAMES/topic) which
+// needs to be sent by the IRC server on join.
+func (s *Server) HandleChannelJoined(channelName string) {
+	s.RLock()
+	for _, v := range s.clientConnections {
+		v.handleChannelJoined(channelName)
+	}
+	s.RUnlock()
+}
+
 // ServerStateProvider contains methods used by the IRC server to answer
 // client queries about channels and their members.
 type ServerStateProvider interface {

--- a/main.go
+++ b/main.go
@@ -200,6 +200,8 @@ Loop:
 			case gateway.TopicChangeEvent:
 				t := slackToTopic(msg.Data.(*gateway.TopicChangeEventData))
 				sendChan <- t.ToMessage()
+			case gateway.SelfJoinEvent:
+				server.HandleChannelJoined(msg.Data.(*gateway.JoinPartEventData).Target)
 			case gateway.JoinEvent:
 				j := slackToJoin(msg.Data.(*gateway.JoinPartEventData))
 				sendChan <- j.ToMessage()


### PR DESCRIPTION
This new type exists solely for the benefit of the IRC server, which apparently needs to send NAMES and the channel topic before clients recognize that the channel has been joined. (HexChat will not display user lists until this has been performed, for example.)

We wire up the existing `handleChannelJoined` functionality (which was previously only executed when an IRC client sent a JOIN, or on IRC client connect) to also trigger when Slack sends a `member_joined_channel` event over the WebSocket connection.

Note that the similarly named `channel_joined` event is still unhandled, and is not necessary for proper functioning.