### PR TITLE
Fix nil pointer dereference on `user_change` part 2.

### DIFF
--- a/gateway/slack.go
+++ b/gateway/slack.go
@@ -426,11 +426,11 @@ func (sc *SlackClient) Poop(chans *ClientChans) {
 
 				// Atomically check and replace the old user info object with the new
 				sc.Lock()
-				oldUserInfo, exists := sc.userInfo[userData.User.ID]
+				oldUserInfo, hadOldUserInfo := sc.userInfo[userData.User.ID]
 				sc.userInfo[newUserInfo.SlackID] = newUserInfo
 
 				// Un-map the old nick, if we had one, and insert an entry for the new
-				if exists {
+				if hadOldUserInfo {
 					delete(sc.nickToUserMap, oldUserInfo.Nick)
 				}
 				sc.nickToUserMap[newUserInfo.Nick] = newUserInfo.SlackID
@@ -442,7 +442,7 @@ func (sc *SlackClient) Poop(chans *ClientChans) {
 				sc.Unlock()
 
 				// Send nick change event if necessary
-				if (oldUserInfo != nil) && (oldUserInfo.Nick != newUserInfo.Nick) {
+				if hadOldUserInfo && (oldUserInfo.Nick != newUserInfo.Nick) {
 					chans.IncomingChan <- &SlackEvent{
 						EventType: NickChangeEvent,
 						Data: &NickChangeEventData{

--- a/gateway/slack.go
+++ b/gateway/slack.go
@@ -422,17 +422,20 @@ func (sc *SlackClient) Poop(chans *ClientChans) {
 
 			case "user_change":
 				userData := event.Data.(*slack.UserChangeEvent)
-
-				// Update user info based on the new DTO
-				oldUserInfo := sc.userInfo[userData.User.ID]
 				newUserInfo := slackUserFromDto(&userData.User)
 
-				// Atomically replace the old user info object with the new
-				// Here we also need to update sc.self if our user info was updated
+				// Atomically check and replace the old user info object with the new
 				sc.Lock()
+				oldUserInfo, exists := sc.userInfo[userData.User.ID]
 				sc.userInfo[newUserInfo.SlackID] = newUserInfo
-				delete(sc.nickToUserMap, oldUserInfo.Nick)
+
+				// Un-map the old nick, if we had one, and insert an entry for the new
+				if exists {
+					delete(sc.nickToUserMap, oldUserInfo.Nick)
+				}
 				sc.nickToUserMap[newUserInfo.Nick] = newUserInfo.SlackID
+
+				// Here we also need to update sc.self if our user info was updated
 				if userData.User.ID == sc.self.SlackID {
 					sc.self = newUserInfo
 				}

--- a/gateway/slack.go
+++ b/gateway/slack.go
@@ -442,7 +442,7 @@ func (sc *SlackClient) Poop(chans *ClientChans) {
 				sc.Unlock()
 
 				// Send nick change event if necessary
-				if oldUserInfo.Nick != newUserInfo.Nick {
+				if (oldUserInfo != nil) && (oldUserInfo.Nick != newUserInfo.Nick) {
 					chans.IncomingChan <- &SlackEvent{
 						EventType: NickChangeEvent,
 						Data: &NickChangeEventData{


### PR DESCRIPTION
Didn't realize the `oldUserInfo` could be a `nil` pointer too...

```panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x685449]
goroutine 25 [running]:
github.com/nolanlum/tanya/gateway.(*SlackClient).Poop(0xc42013e400, 0xc4201150c0)
        /root/tanya/src/github.com/nolanlum/tanya/gateway/slack.go:434 +0x1239
created by main.launchGateway
        /root/tanya/src/github.com/nolanlum/tanya/main.go:221 +0xdf```