### PR TITLE
Mark conversation read on outgoing message.

### DIFF
--- a/gateway/conversation_marking.go
+++ b/gateway/conversation_marking.go
@@ -1,0 +1,83 @@
+package gateway
+
+import (
+	"log"
+	"sync"
+	"time"
+
+	"github.com/nlopes/slack"
+)
+
+// ConversationMarker handles coordination and de-duplication of marking conversations as read
+type ConversationMarker struct {
+	rtmIDToMarkFuncMap          map[int]func(string)
+	conversationToReadCursorMap map[string]string
+
+	sync.Mutex
+}
+
+// NewConversationMarker creates a new conversation marker
+func NewConversationMarker() *ConversationMarker {
+	return &ConversationMarker{
+		rtmIDToMarkFuncMap:          map[int]func(string){},
+		conversationToReadCursorMap: map[string]string{},
+	}
+}
+
+func (cm *ConversationMarker) markConversation(conversationID, timestamp string, mark func(string, string) error) {
+	cm.conversationToReadCursorMap[conversationID] = timestamp
+
+	go func() {
+		time.Sleep(5 * time.Second)
+
+		cm.Lock()
+		defer cm.Unlock()
+		if cm.conversationToReadCursorMap[conversationID] == timestamp {
+			err := mark(conversationID, timestamp)
+			if err != nil {
+				log.Printf("error while marking conversation %v: %v", conversationID, err)
+			}
+		}
+	}()
+}
+
+// HandleRTMAck handles an ACK from the RTM channel, scheduling a read marker update if possible
+func (cm *ConversationMarker) HandleRTMAck(messageID int, timestamp string) {
+	cm.Lock()
+	defer cm.Unlock()
+
+	markFunc, found := cm.rtmIDToMarkFuncMap[messageID]
+	if found {
+		markFunc(timestamp)
+	}
+}
+
+// MarkChannel prepares a channel marker to be updated upon receipt of an ack for the given message ID
+func (cm *ConversationMarker) MarkChannel(sc *slack.Client, channelID string, messageID int) {
+	cm.Lock()
+	defer cm.Unlock()
+
+	cm.rtmIDToMarkFuncMap[messageID] = func(timestamp string) {
+		cm.markConversation(channelID, timestamp, sc.SetChannelReadMark)
+	}
+}
+
+// MarkGroup prepares a group (private channel) marker to be updated upon receipt of an ack for the given message ID
+func (cm *ConversationMarker) MarkGroup(sc *slack.Client, groupID string, messageID int) {
+	cm.Lock()
+	defer cm.Unlock()
+
+	cm.rtmIDToMarkFuncMap[messageID] = func(timestamp string) {
+		cm.markConversation(groupID, timestamp, sc.SetGroupReadMark)
+	}
+}
+
+// MarkDM prepares a DM marker to be updated upon receipt of an ack for the given message ID
+func (cm *ConversationMarker) MarkDM(sc *slack.Client, dmID string, messageID int) {
+	cm.Lock()
+	defer cm.Unlock()
+
+	cm.rtmIDToMarkFuncMap[messageID] = func(timestamp string) {
+		cm.markConversation(dmID, timestamp, sc.MarkIMChannel)
+	}
+}

--- a/gateway/conversation_marking.go
+++ b/gateway/conversation_marking.go
@@ -48,6 +48,7 @@ func (cm *ConversationMarker) HandleRTMAck(messageID int, timestamp string) {
 
 	markFunc, found := cm.rtmIDToMarkFuncMap[messageID]
 	if found {
+		delete(cm.rtmIDToMarkFuncMap, messageID)
 		markFunc(timestamp)
 	}
 }

--- a/irc/client.go
+++ b/irc/client.go
@@ -195,19 +195,23 @@ SelectLoop:
 			case ModeCmd:
 				if len(msg.Params) < 1 || msg.Params[0][0] != '#' {
 					// For Slack we only want to handle querying channel modes...
-					// And they'll always be just +nt
 					continue
 				}
 
+				channelName := msg.Params[0]
+				channelModes := "+nt"
+				if cc.stateProvider.GetChannelPrivate(channelName) {
+					channelModes += "sp"
+				}
 				cc.outgoingMessages <- cc.reply(NumericReply{
 					Code:   RPL_CHANNELMODEIS,
-					Params: []string{msg.Params[0], "+nt"},
+					Params: []string{channelName, channelModes},
 				})
 
-				ctime := cc.stateProvider.GetChannelCTime(msg.Params[0])
+				ctime := cc.stateProvider.GetChannelCTime(channelName)
 				cc.outgoingMessages <- cc.reply(NumericReply{
 					Code:   RPL_CREATIONTIME,
-					Params: []string{msg.Params[0], fmt.Sprintf("%v", ctime.Unix())},
+					Params: []string{channelName, fmt.Sprintf("%v", ctime.Unix())},
 				})
 
 			case TopicCmd:

--- a/irc/server.go
+++ b/irc/server.go
@@ -211,6 +211,8 @@ type ServerStateProvider interface {
 
 	GetChannelCTime(channelName string) time.Time
 
+	GetChannelPrivate(channelName string) bool
+
 	GetJoinedChannels() []string
 
 	SendPrivmsg(privMsg *Privmsg)

--- a/main.go
+++ b/main.go
@@ -131,6 +131,17 @@ func (c *corpusCallosum) GetChannelCTime(channelName string) time.Time {
 	return channel.Created
 }
 
+// GetChannelPrivate implements irc.ServerStateProvider.GetChannelPrivate
+func (c *corpusCallosum) GetChannelPrivate(channelName string) bool {
+	channel := c.sc.ResolveNameToChannel(channelName)
+	if channel == nil {
+		log.Printf("error while querying private flag for %v: channel_not_found", channelName)
+		return false
+	}
+
+	return channel.Private
+}
+
 // GetJoinedChannels implements irc.ServerStateProvider.GetJoinedChannels
 func (c *corpusCallosum) GetJoinedChannels() []string {
 	var channelNames []string


### PR DESCRIPTION
This is handled by adding additional logic to remember RTM message IDs, and the ID and type of their destinations.

Also set mode `+sp` on private channels while we're at it...