### PR TITLE
Fix panic while parsing malformed message.

### DIFF
--- a/gateway/message_parser.go
+++ b/gateway/message_parser.go
@@ -63,8 +63,10 @@ func (sc *SlackClient) ParseMessageTextWithOptions(text string, includeCanonical
 		}
 
 		// Do it again I guess.
-		textParts = strings.SplitN(textParts[1], "<", 2)
-		parsedMessageBuilder.WriteString(textParts[0])
+		if len(textParts) > 1 {
+			textParts = strings.SplitN(textParts[1], "<", 2)
+			parsedMessageBuilder.WriteString(textParts[0])
+		}
 	}
 
 	return sc.slackURLDecoder.Replace(parsedMessageBuilder.String())

--- a/gateway/message_parser_test.go
+++ b/gateway/message_parser_test.go
@@ -48,8 +48,8 @@ func TestSlackClient_ParseMessageText(t *testing.T) {
 		{
 			name:   "generic vanilla URL",
 			fields: fields{},
-			text:   "Fork this cool github repo <http://github.com/nolanlum/tanya> xD",
-			want:   "Fork this cool github repo http://github.com/nolanlum/tanya xD",
+			text:   "Fork this cool github repo xD <http://github.com/nolanlum/tanya>",
+			want:   "Fork this cool github repo xD http://github.com/nolanlum/tanya",
 		},
 		{
 			name:   "URL detected by slack",
@@ -62,6 +62,12 @@ func TestSlackClient_ParseMessageText(t *testing.T) {
 			fields: fields{},
 			text:   "send cool pics of girls to <mailto:kedo@calanimagealpha.com|kedo@calanimagealpha.com> xD",
 			want:   "send cool pics of girls to kedo@calanimagealpha.com xD",
+		},
+		{
+			name:   "malformed",
+			fields: fields{},
+			text:   "le disconnect face <https://warosu.",
+			want:   "le disconnect face https://warosu.",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
```
2019/09/09 16:38:18 websocket_managed_conn.go:191: killing connection
panic: runtime error: index out of range
goroutine 10 [running]:
github.com/nolanlum/tanya/gateway.(*SlackClient).ParseMessageTextWithOptions(0xc0001021b0, 0xc0001fa000, 0xfe4, 0xc000046000, 0xc000196ee0, 0xc000102220)
/root/tanya/src/github.com/nolanlum/tanya/gateway/message_parser.go:66 +0x1103
github.com/nolanlum/tanya/gateway.(*SlackClient).ParseMessageText(0xc0001021b0, 0xc0001fa000, 0xfe4, 0xc000196ee0, 0x0)
/root/tanya/src/github.com/nolanlum/tanya/gateway/message_parser.go:13 +0x44
github.com/nolanlum/tanya/gateway.(*SlackClient).handleMessageEvent(0xc0001021b0, 0xc00001a300, 0xc000b98d80)
/root/tanya/src/github.com/nolanlum/tanya/gateway/message_handler.go:100 +0x148
github.com/nolanlum/tanya/gateway.(*SlackClient).Poop(0xc0001021b0, 0xc00000cc80)
/root/tanya/src/github.com/nolanlum/tanya/gateway/slack.go:467 +0x7cf
created by main.launchGateway
/root/tanya/src/github.com/nolanlum/tanya/main.go:232 +0xd6
```