### PR TITLE
Bring CI setup into 2021.

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -1,11 +1,11 @@
-name: Go Lint
+name: Go
 on:
   push:
+    tags: [ v* ]
     branches: [ master ]
   pull_request:
-    branches: [ master ]
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -1,0 +1,15 @@
+name: Go Lint
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run golangci-lint
+      uses: golangci/golangci-lint-action@v2.5.1
+      with:
+        version: v1.37.1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,15 @@
+run:
+  timeout: 6m
+  issues-exit-code: 1
+linters:
+  disable-all: true
+  enable:
+    - goimports
+    - govet
+    - gosimple
+    - ineffassign
+    - staticcheck
+    - structcheck
+    - interfacer
+    - misspell
+    - unconvert

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: go
 go:
 - '1.16'
-git:
-  submodules: true
 script:
 - go build -v
 - go test -v -race ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,17 @@
 language: go
 go:
-- '1.10'
-env:
-- GOMETALINTER_VER=2.0.5
-before_script:
-- pushd $HOME
-- wget https://github.com/alecthomas/gometalinter/releases/download/v${GOMETALINTER_VER}/gometalinter-${GOMETALINTER_VER}-linux-amd64.tar.gz
-- tar -xzvf gometalinter-${GOMETALINTER_VER}-linux-amd64.tar.gz
-- popd
-- PATH=$HOME/gometalinter-${GOMETALINTER_VER}-linux-amd64:$PATH
+- '1.16'
+git:
+  submodules: true
 script:
 - go build -v
 - go test -v -race ./...
-- gometalinter --disable-all --vendor --enable=goimports --enable=gofmt --enable=vet
-  --enable=vetshadow --enable=golint --enable=ineffassign --enable=megacheck ./...
 deploy:
   provider: releases
   api_key:
     secure: QMIOGmhEItn3hroZ7egd5qCeP59Z2lUScUbhi7SAE7KJbE8rFohtOWnO8xKpjERwf+aDHBm9GaI2YfLtRW80JWk4UT632cREkxNdFmIF6ElrToG3N0uoazMsu4i7DWLJqvW7xtNCmZyw89ajb89UOo7aBIdjyrmqKEgwsX06wuY8OtZoSJf+fTmYu7kaZ7l69Lx3WsBXZOlHhNq82Lv9FsWwRmIT2Y9p0L6lMV418yCrpelrLLzJTTJogyBRbr1VfLbmfBLYnmZBML6D/QW/IgZR6kj8vPBBeYlxAWvo3/r3HNQa3Z1V6sK2GoilQA9ofkgNQbiilztQkq4ztX3tOfb9PGvW9QQGugRHfXwu4IQ7wiNQECe12aakhb90KKRfFhiAzAYBfOTdRwwc/C5+I9t6kbQ32P0xz0+1mYtBGZVgmnQ1LOwKrcnIlMkhD/tFU4j4ndMhzpFbzKU1HE8Dyl8MVuZqd2018lIxIMHiCxeONaa/r+e2/8m0Idaj4VikvJsYj2UxYsddzaEJWWBjZwSivXPDN0OURwPDDjyDtbFlUtHPLXJpDM+43ECFWsIIGCkvfbRc6asGG/oIVhbQJUApHVf86+0DtH8m9mLXP4iRX7BXda7u3t8uncHnw/wxuEYtrCAP9LCf9aE6iJ4/DT5i5hbXnvG1RmuEDo2YkSE=
   file: tanya
-  skip_cleanup: true
+  cleanup: false
   on:
     repo: nolanlum/tanya
     tags: true


### PR DESCRIPTION
* Drop gometalinter in favor of golangci-lint.
* Move lint from Travis CI to GitHub Actions.