### PR TITLE
Rate Limit getConversations

### DIFF
--- a/gateway/slack.go
+++ b/gateway/slack.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"math/rand"
@@ -11,6 +12,9 @@ import (
 
 	"github.com/slack-go/slack"
 )
+
+// Number of times GetConversations calls should be retried
+const getConvoRetries = 3
 
 // SlackChannel holds data for a channel on Slack
 type SlackChannel struct {
@@ -119,6 +123,30 @@ func NewSlackClient() *SlackClient {
 	}
 }
 
+func (sc *SlackClient) getConversations(gcp *slack.GetConversationsParameters) (channels []slack.Channel, cursor string, err error) {
+	var rateLimitErr *slack.RateLimitedError
+	var ok bool
+
+	for retries := 0; retries < getConvoRetries; retries++ {
+		channels, cursor, err = sc.client.GetConversations(gcp)
+		if err != nil {
+			if !errors.As(err, &rateLimitErr) {
+				ok = false
+				break
+			}
+			time.Sleep(rateLimitErr.RetryAfter)
+			continue
+		}
+		ok = true
+	}
+
+	if !ok {
+		return nil, "", err
+	}
+
+	return channels, cursor, nil
+}
+
 // Clear all stored state and reload workspace/conversation metadata from Slack.
 // Called upon reconnection to ensure all cached state is up-to-date.
 func (sc *SlackClient) bootstrapMappings() {
@@ -138,7 +166,8 @@ func (sc *SlackClient) bootstrapMappings() {
 	for hasMore {
 		var channels []slack.Channel
 		var err error
-		channels, gcp.Cursor, err = sc.client.GetConversations(gcp)
+
+		channels, gcp.Cursor, err = sc.getConversations(gcp)
 		if err != nil {
 			log.Fatalf("%s [fatal] slack:init %s err: %v", sc.Tag(), "GetConversations", err)
 		}
@@ -169,7 +198,7 @@ func (sc *SlackClient) bootstrapMappings() {
 		Limit:           0,
 		ExcludeArchived: true,
 	}
-	ims, _, err := sc.client.GetConversations(ucParams)
+	ims, _, err := sc.getConversations(ucParams)
 	if err != nil {
 		log.Fatalf("%s [fatal] slack:init %s err: %v", sc.Tag(), "GetConversations", err)
 	}
@@ -378,7 +407,7 @@ func (sc *SlackClient) ResolveDMToUser(dmChannelID string) (*SlackUser, error) {
 		Limit:           0,
 		ExcludeArchived: true,
 	}
-	ims, _, err := sc.client.GetConversations(ucParams)
+	ims, _, err := sc.getConversations(ucParams)
 	if err != nil {
 		return nil, err
 	}

--- a/gateway/slack.go
+++ b/gateway/slack.go
@@ -134,6 +134,7 @@ func (sc *SlackClient) getConversations(gcp *slack.GetConversationsParameters) (
 				ok = false
 				break
 			}
+			log.Printf("%s slack:getconversations ratelimit wait for %s seconds", sc.Tag(), rateLimitErr.RetryAfter.String())
 			time.Sleep(rateLimitErr.RetryAfter)
 			continue
 		}


### PR DESCRIPTION
Respect Slack API rate limits in `getConversations` usages by using a wrapper function which sleeps and then retries.