### PR TITLE
Better handling of JOIN/PART events.

### DIFF
--- a/gateway/message_handler.go
+++ b/gateway/message_handler.go
@@ -199,7 +199,7 @@ func (sc *SlackClient) handleMessageEvent(incomingChan chan<- *SlackEvent, messa
 			},
 		}
 
-	case "channel_leave", "channel_join":
+	case "channel_leave", "channel_join", "channel_archive", "channel_unarchive":
 		// These are already handled elsewhere, drop the message event.
 		return
 

--- a/irc/numerics.go
+++ b/irc/numerics.go
@@ -35,6 +35,7 @@ const (
 	RPL_ENDOFMOTD  NumericCommand = 376
 
 	ERR_NOSUCHNICK     NumericCommand = 401
+	ERR_NOSUCHCHANNEL  NumericCommand = 403
 	ERR_UNKNOWNCOMMAND NumericCommand = 421
 	ERR_NEEDMOREPARAMS NumericCommand = 461
 )
@@ -181,6 +182,14 @@ func ErrNoSuchNick(nick string) *NumericReply {
 	return &NumericReply{
 		Code:   ERR_NOSUCHNICK,
 		Params: []string{nick, "No such nick/channel"},
+	}
+}
+
+// ErrNoSuchChannel is the numeric reply to a command which provides a channel that doesn't exist
+func ErrNoSuchChannel(channelName string) *NumericReply {
+	return &NumericReply{
+		Code:   ERR_NOSUCHCHANNEL,
+		Params: []string{channelName, "No such channel"},
 	}
 }
 

--- a/irc/numerics_test.go
+++ b/irc/numerics_test.go
@@ -232,3 +232,15 @@ func TestErrUnknownCommand(t *testing.T) {
 		t.Errorf("ErrUnknownCommand() = %v, want %v", got, want)
 	}
 }
+
+func TestErrNoSuchChannel(t *testing.T) {
+	want := &NumericReply{
+		Code:   ERR_NOSUCHCHANNEL,
+		Params: []string{"#poop", "No such channel"},
+	}
+	got := ErrNoSuchChannel("#poop")
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ErrNoSuchChannel() = %v, want %v", got, want)
+	}
+}

--- a/irc/server.go
+++ b/irc/server.go
@@ -15,10 +15,10 @@ var tanyaInternalUser = &User{Nick: "*tanya", Ident: "tanya"}
 // and fanning out Slack events as necessary
 type Server struct {
 	clientConnections map[net.Addr]*clientConnection
-	stopChan          <-chan interface{}
+	stopChan          <-chan struct{}
 
 	initOnce sync.Once
-	initChan chan interface{}
+	initChan chan struct{}
 
 	selfUser      User
 	config        *Config
@@ -42,12 +42,12 @@ type ChannelTopic struct {
 }
 
 // NewServer creates a new IRC server
-func NewServer(config *Config, stopChan <-chan interface{}, stateProvider ServerStateProvider) *Server {
+func NewServer(config *Config, stopChan <-chan struct{}, stateProvider ServerStateProvider) *Server {
 	return &Server{
 		clientConnections: make(map[net.Addr]*clientConnection),
 		stopChan:          stopChan,
 
-		initChan: make(chan interface{}),
+		initChan: make(chan struct{}),
 
 		config:        config,
 		stateProvider: stateProvider,
@@ -224,6 +224,8 @@ func (s *Server) HandleChannelJoined(channelName string) {
 // ServerStateProvider contains methods used by the IRC server to answer
 // client queries about channels and their members.
 type ServerStateProvider interface {
+	ChannelExists(channelName string) bool
+
 	GetChannelUsers(channelName string) []User
 
 	GetChannelTopic(channelName string) ChannelTopic


### PR DESCRIPTION
- Channels joined by a particular IRC client connection are now tracked at that level. This way, if a client locally `PART`s a Slack channel (even though the state does not update on the Slack side), we can allow the client to re-join a channel (once) without having to reconnect. Previously there was no way to re-join a channel you left on an IRC client (we would never send the `JOIN` echo since we checked joined channels against Slack).
- Add handling for `channel_joined` and `channel_left`. This information was duplicated by `member_joined_channel` and `member_left_channel`, with the sole exception of channel archiving, which does not generate `member_left_channel`. We now ignore the `member_*` variant for the self user.
- Replace `chan interface{}` and `map[x]interface{}` with `struct{}` lmbo.
- Ignore known and unimportant unmarshalling errors.